### PR TITLE
Store Terraform state remotely in S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This repo is an experiment to apply the practices of [Infrastructure as Code][1]
 * *Sustainability* - With better documentation and better participation, we will build a more sustainable organization.
 
 ## Setup (macOS)
+_*Note:* If you are looking to set up the infra repo for your Brigade, see [README.setup.md][setup] for how to set up the repo for the first time._
+
+To run Terraform within OpenOakland, follow these instructions:
+
 Prerequisites: [Homebrew][2]
 
 ```bash
@@ -25,9 +29,8 @@ chmod 600 ~/.ssh/id_rsa_openoakland
 
 [1]: https://en.wikipedia.org/wiki/Infrastructure_as_Code
 [2]: https://brew.sh/
+[setup]: https://github.com/openoakland/infra/blob/master/README.setup.md
 
 ## TODO:
 * Create an SSH key which isn't anyone's personal key to use for provisioning a machine
-* Check in IAM policy needed for people running terraform
-* Create an S3 bucket to store terraform state (that is only accessible by the terraformers)
 * Use Ansible or some kind of desired-state configuration so that all the setup isn't in terraform

--- a/README.setup.md
+++ b/README.setup.md
@@ -1,0 +1,52 @@
+# Repo Setup
+
+## 1. Create an S3 Bucket
+Use almost the default settings in the S3 wizard. We named ours "openoakland-infra".
+
+* Enable versioning
+
+
+## 2. Create a DynamoDB Table
+We created ours accordingly:
+
+* *Table Name:* `openoakland_infra`
+* *Primary Key:* `LockID`
+
+
+## 3. Create an IAM policy for people with Terraform permissions
+
+<details>
+<summary>Copy this JSON into the IAM policy editor</summary>
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::openoakland-infra"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": "arn:aws:s3:::openoakland-infra/terraform"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:DeleteItem"
+      ],
+      "Resource": "arn:aws:dynamodb:*:*:openoakland-infra/terraform"
+    }
+  ]
+}
+```
+</details>
+
+## 4. Initialize the repo
+```
+terraform init
+```

--- a/terraform.tf
+++ b/terraform.tf
@@ -7,6 +7,15 @@ data "aws_route53_zone" "openoakland" {
   name = "aws.openoakland.org"
 }
 
+terraform {
+  backend "s3" {
+    bucket = "openoakland-infra"
+    key    = "terraform.tfstate"
+    region = "us-west-2"
+    dynamodb_table = "openoakland_infra"
+  }
+}
+
 resource "aws_security_group" "ssh_and_web" {
   name = "ssh_and_web"
   description = "Allow SSH and Web connections"


### PR DESCRIPTION
This moves the remote state from my laptop to S3 and creates a DynamoDB
table for locking. :rocket:

Also, this adds a bit of documentation for anyone else looking to do the
same (although Terraform's documentation is largely sufficient here.)

Mind taking a look @adborden ?