### PR TITLE
Oakcrime db fix

### DIFF
--- a/modules/oakcrime/terraform.tf
+++ b/modules/oakcrime/terraform.tf
@@ -65,7 +65,7 @@ module "db_production" {
   db_name     = "oakcrime"
   db_password = "${var.prod_db_password}"
   db_username = "oakcrime"
-  namespace   = "oakcrime-prod"
+  namespace   = "oakcrime-production"
 }
 
 module "env_web_production" {

--- a/modules/oakcrime/terraform.tf
+++ b/modules/oakcrime/terraform.tf
@@ -60,8 +60,9 @@ module "app_oakcrime" {
 }
 
 module "db_production" {
-  source = "github.com/openoakland/terraform-modules//postgresdb?ref=v2.0.0"
+  source = "github.com/openoakland/terraform-modules//postgresdb?ref=v2.0.1"
 
+  db_engine_version = "10.6"
   db_name     = "oakcrime"
   db_password = "${var.prod_db_password}"
   db_username = "oakcrime"


### PR DESCRIPTION
Once I imported the database from the previous terraform code in OakCrime, I had the wrong name so terraform wanted to destroy and recreate the database.

Also need to specify a newer database engine_version. The v2.0.1 doesn't exist yet, https://github.com/openoakland/terraform-modules/pull/3 includes the fix. Once merged, I'll bump the version.