### PR TITLE
Upgrade to 0.12 and add two oakcrime variables

### DIFF
--- a/councilmatic.tf
+++ b/councilmatic.tf
@@ -1,6 +1,6 @@
 module "councilmatic" {
-  source = "./modules/councilmatic"
-  security_group_name = "${aws_security_group.ssh_and_web.name}"
-  key_pair_id = "${aws_key_pair.openoakland.id}"
-  zone_id = "${data.aws_route53_zone.openoakland.id}"
+  source              = "./modules/councilmatic"
+  security_group_name = aws_security_group.ssh_and_web.name
+  key_pair_id         = aws_key_pair.openoakland.id
+  zone_id             = data.aws_route53_zone.openoakland.id
 }

--- a/env.sample
+++ b/env.sample
@@ -4,3 +4,5 @@ export AWS_SECRET_ACCESS_KEY=
 export TF_VAR_oakcrime_prod_db_password=
 export TF_VAR_oakcrime_prod_django_secret_key=
 export TF_VAR_oakcrime_prod_socrata_key=
+export TF_VAR_oakcrime_prod_google_maps_api_key=
+export TF_VAR_oakcrime_prod_opd_key=

--- a/modules/councilmatic/providers.tf
+++ b/modules/councilmatic/providers.tf
@@ -1,0 +1,5 @@
+provider "aws" {}
+provider "aws" {
+  alias = "cloudfront"
+}
+

--- a/modules/oakcrime/terraform.tf
+++ b/modules/oakcrime/terraform.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  alias = "cloudfront"
+}
+
 module "ci_user" {
   source = "github.com/openoakland/terraform-modules//eb_deploy_user?ref=v2.0.0"
 
@@ -15,7 +19,7 @@ module "db_production" {
 
   db_engine_version = "10.6"
   db_name     = "oakcrime"
-  db_password = "${var.prod_db_password}"
+  db_password = var.prod_db_password
   db_username = "oakcrime"
   namespace   = "oakcrime-production"
 }
@@ -30,10 +34,12 @@ module "env_web_production" {
   security_groups = ["${module.db_production.security_group_name}"]
 
   environment_variables = {
-    DATABASE_URL = "${module.db_production.postgis_database_url}"
-    EMAIL_URL    = "smtp://localhost"
-    SECRET_KEY   = "${var.prod_django_secret_key}"
-    SERVER_EMAIL = "root@localhost"
+    DATABASE_URL        = module.db_production.postgis_database_url
+    EMAIL_URL           = "smtp://localhost"
+    GOOGLE_MAPS_API_KEY = var.prod_google_maps_api_key
+    OPD_KEY             = var.prod_opd_key
+    SECRET_KEY          = var.prod_django_secret_key
+    SERVER_EMAIL        = "root@localhost"
   }
 }
 
@@ -44,14 +50,16 @@ module "env_worker_production" {
   app_name     = "oakcrime"
   key_pair     = "oakcrime"
   name         = "oakcrime-production-worker"
-  security_groups = ["${module.db_production.security_group_name}"]
+  security_groups = [module.db_production.security_group_name]
 
   environment_variables = {
-    DATABASE_URL    = "${module.db_production.postgis_database_url}"
-    EMAIL_URL       = "smtp://localhost"
-    OAKCRIME_WORKER = "1"
-    SECRET_KEY      = "${var.prod_django_secret_key}"
-    SERVER_EMAIL    = "root@localhost"
-    SOCRATA_KEY     = "${var.prod_socrata_key}"
+    DATABASE_URL        = module.db_production.postgis_database_url
+    EMAIL_URL           = "smtp://localhost"
+    GOOGLE_MAPS_API_KEY = var.prod_google_maps_api_key
+    OAKCRIME_WORKER     = "1"
+    OPD_KEY             = var.prod_opd_key
+    SECRET_KEY          = var.prod_django_secret_key
+    SERVER_EMAIL        = "root@localhost"
+    SOCRATA_KEY         = var.prod_socrata_key
   }
 }

--- a/modules/oakcrime/variables.tf
+++ b/modules/oakcrime/variables.tf
@@ -5,18 +5,28 @@ variable "zone_id" {}
 # pwgen -s -N 1 20
 variable "prod_db_password" {
   description = "Production password for the RDS database."
-  type        = "string"
+  type        = string
 }
 
 # pwgen -s -N 1 50
 variable "prod_django_secret_key" {
   description = "Production SECRET_KEY setting to provide the Django application."
-  type        = "string"
+  type        = string
+}
+
+variable "prod_google_maps_api_key" {
+  description = "Key for Google Maps API used for geocoding"
+  type        = string
+}
+
+variable "prod_opd_key" {
+  description = "Key for accessing OPD Box.com API"
+  type        = string
 }
 
 variable "prod_socrata_key" {
   description = "Socrata API key for accessing data.oaklandnet.com"
-  type        = "string"
+  type        = string
 }
 
 variable "dns_zone" {

--- a/modules/openoakland.org/main.tf
+++ b/modules/openoakland.org/main.tf
@@ -1,24 +1,20 @@
 provider "aws" {
-  alias = "main"
-}
-
-provider "aws" {
   alias = "cloudfront"
 }
 
 module "site" {
-  source = "github.com/openoakland/terraform-modules//s3_cloudfront_website?ref=s3-cloudfront-website"
+  source = "github.com/openoakland/terraform-modules//s3_cloudfront_website"
   host   = "beta"
   zone   = "aws.openoakland.org"
 
   providers = {
-    aws.main       = "aws.main"
-    aws.cloudfront = "aws.cloudfront"
+    aws.main       = aws
+    aws.cloudfront = aws.cloudfront
   }
 }
 
 module "ci_user" {
-  source = "github.com/openoakland/terraform-modules//s3_deploy_user?ref=s3-cloudfront-website"
+  source = "github.com/openoakland/terraform-modules//s3_deploy_user"
 
   username      = "ci-openoakland-org"
   s3_bucket_arn = "${module.site.s3_bucket_arn}"

--- a/modules/openoakland.org/outputs.tf
+++ b/modules/openoakland.org/outputs.tf
@@ -1,9 +1,9 @@
 output "aws_access_key_id" {
-  value     = "${module.ci_user.access_key_id}"
+  value     = module.ci_user.access_key_id
   sensitive = true
 }
 
 output "aws_secret_access_key" {
-  value     = "${module.ci_user.secret_access_key}"
+  value     = module.ci_user.secret_access_key
   sensitive = true
 }

--- a/oakcrime.tf
+++ b/oakcrime.tf
@@ -10,25 +10,35 @@ variable "oakcrime_prod_socrata_key" {
   description = "socrata_key for the production app."
 }
 
+variable "oakcrime_prod_google_maps_api_key" {
+  description = "Google Maps API key for the production app."
+}
+
+variable "oakcrime_prod_opd_key" {
+  description = "opd_key for the production app."
+}
+
 module "oakcrime" {
   source              = "./modules/oakcrime"
-  security_group_name = "${aws_security_group.ssh_and_web.name}"
-  key_pair_id         = "${aws_key_pair.openoakland.id}"
-  zone_id             = "${data.aws_route53_zone.openoakland.id}"
+  security_group_name = aws_security_group.ssh_and_web.name
+  key_pair_id         = aws_key_pair.openoakland.id
+  zone_id             = data.aws_route53_zone.openoakland.id
 
   # Beanstalk apps
-  prod_db_password       = "${var.oakcrime_prod_db_password}"
-  prod_django_secret_key = "${var.oakcrime_prod_django_secret_key}"
-  prod_socrata_key       = "${var.oakcrime_prod_socrata_key}"
-  dns_zone               = "${data.aws_route53_zone.openoakland.name}"
+  prod_db_password         = var.oakcrime_prod_db_password
+  prod_django_secret_key   = var.oakcrime_prod_django_secret_key
+  prod_google_maps_api_key = var.oakcrime_prod_google_maps_api_key
+  prod_opd_key             = var.oakcrime_prod_opd_key
+  prod_socrata_key         = var.oakcrime_prod_socrata_key
+  dns_zone                 = data.aws_route53_zone.openoakland.name
 }
 
 output "oakcrime_ci_aws_access_key_id" {
-  value     = "${module.oakcrime.ci_aws_access_key_id}"
+  value     = module.oakcrime.ci_aws_access_key_id
   sensitive = true
 }
 
 output "oakcrime_ci_aws_secret_access_key" {
-  value     = "${module.oakcrime.ci_aws_secret_access_key}"
+  value     = module.oakcrime.ci_aws_secret_access_key
   sensitive = true
 }

--- a/openoakland.org.tf
+++ b/openoakland.org.tf
@@ -2,17 +2,17 @@ module "openoakland_org" {
   source = "./modules/openoakland.org"
 
   providers = {
-    aws.main = "aws"
-    aws.cloudfront = "aws.cloudfront"
+    aws            = aws
+    aws.cloudfront = aws.cloudfront
   }
 }
 
 output "openoakland_org_aws_access_key_id" {
-  value     = "${module.openoakland_org.aws_access_key_id}"
+  value     = module.openoakland_org.aws_access_key_id
   sensitive = true
 }
 
 output "openoakland_org_aws_secret_access_key" {
-  value     = "${module.openoakland_org.aws_secret_access_key}"
+  value     = module.openoakland_org.aws_secret_access_key
   sensitive = true
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -15,47 +15,47 @@ data "aws_route53_zone" "openoakland" {
 
 terraform {
   backend "s3" {
-    bucket = "openoakland-infra"
-    key    = "terraform.tfstate"
-    region = "us-west-2"
+    bucket         = "openoakland-infra"
+    key            = "terraform.tfstate"
+    region         = "us-west-2"
     dynamodb_table = "openoakland_infra"
   }
 }
 
 resource "aws_security_group" "ssh_and_web" {
-  name = "ssh_and_web"
+  name        = "ssh_and_web"
   description = "Allow SSH and Web connections"
 
   ingress {
-    from_port = 22
-    to_port = 22
-    protocol = "tcp"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
-    from_port = 80
-    to_port = 80
-    protocol = "tcp"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
-    from_port = 443
-    to_port = 443
-    protocol = "tcp"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
 
 resource "aws_key_pair" "openoakland" {
-  key_name = "OpenOakland"
-  public_key = "${file("ssh-keys/openoakland.pub")}"
+  key_name   = "OpenOakland"
+  public_key = file("ssh-keys/openoakland.pub")
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Lots of syntax changes for 0.12, and a bit of fiddling with explicit
provider definitions.

This commit started out as adding two new oakcrime environment
variables: GOOGLE_MAPS_API_KEY, and OPD_KEY, which are used for
geocoding and downloading patrol log PDFs, respectively.