### PR TITLE
Upgrade to Terraform 0.12; Update OakCrime variables

### DIFF
--- a/councilmatic.tf
+++ b/councilmatic.tf
@@ -3,4 +3,9 @@ module "councilmatic" {
   security_group_name = aws_security_group.ssh_and_web.name
   key_pair_id         = aws_key_pair.openoakland.id
   zone_id             = data.aws_route53_zone.openoakland.id
+
+  providers = {
+    aws = aws
+    aws.cloudfront = aws.cloudfront
+  }
 }

--- a/councilmatic.tf
+++ b/councilmatic.tf
@@ -1,6 +1,6 @@
 module "councilmatic" {
-  source = "./modules/councilmatic"
-  security_group_name = "${aws_security_group.ssh_and_web.name}"
-  key_pair_id = "${aws_key_pair.openoakland.id}"
-  zone_id = "${data.aws_route53_zone.openoakland.id}"
+  source              = "./modules/councilmatic"
+  security_group_name = aws_security_group.ssh_and_web.name
+  key_pair_id         = aws_key_pair.openoakland.id
+  zone_id             = data.aws_route53_zone.openoakland.id
 }

--- a/env.sample
+++ b/env.sample
@@ -4,3 +4,5 @@ export AWS_SECRET_ACCESS_KEY=
 export TF_VAR_oakcrime_prod_db_password=
 export TF_VAR_oakcrime_prod_django_secret_key=
 export TF_VAR_oakcrime_prod_socrata_key=
+export TF_VAR_oakcrime_prod_google_maps_api_key=
+export TF_VAR_oakcrime_prod_opd_key=

--- a/env.sample
+++ b/env.sample
@@ -1,8 +1,13 @@
 export AWS_ACCESS_KEY_ID=
 export AWS_SECRET_ACCESS_KEY=
 
+export TF_VAR_oakcrime_prod_box_client_id=
+export TF_VAR_oakcrime_prod_box_client_secret=
+export TF_VAR_oakcrime_prod_box_enterprise_id=
+export TF_VAR_oakcrime_prod_box_pass_phrase=
+export TF_VAR_oakcrime_prod_box_public_key_id=
+export TF_VAR_oakcrime_prod_box_rsa_key=
 export TF_VAR_oakcrime_prod_db_password=
 export TF_VAR_oakcrime_prod_django_secret_key=
-export TF_VAR_oakcrime_prod_socrata_key=
 export TF_VAR_oakcrime_prod_google_maps_api_key=
-export TF_VAR_oakcrime_prod_opd_key=
+export TF_VAR_oakcrime_prod_socrata_key=

--- a/modules/councilmatic/providers.tf
+++ b/modules/councilmatic/providers.tf
@@ -1,0 +1,5 @@
+provider "aws" {}
+provider "aws" {
+  alias = "cloudfront"
+}
+

--- a/modules/councilmatic/providers.tf
+++ b/modules/councilmatic/providers.tf
@@ -1,5 +1,0 @@
-provider "aws" {}
-provider "aws" {
-  alias = "cloudfront"
-}
-

--- a/modules/councilmatic/terraform.tf
+++ b/modules/councilmatic/terraform.tf
@@ -1,3 +1,8 @@
+// passed in to the module via a "providers" block:
+provider "aws" {
+  alias = "cloudfront"
+}
+
 variable "security_group_name" {}
 variable "key_pair_id" {}
 variable "zone_id" {}
@@ -6,16 +11,17 @@ resource "aws_instance" "councilmatic" {
   ami = "ami-0afae182eed9d2b46"
   instance_type = "t2.small"
   associate_public_ip_address = true
-  security_groups = ["${var.security_group_name}"]
+  security_groups = [var.security_group_name]
   key_name = var.key_pair_id
 
-  tags {
+  tags = {
     Name = "Councilmatic"
   }
 
   provisioner "remote-exec" {
     connection {
       type = "ssh"
+      host = self.public_ip
       user = "ubuntu"
       // TODO: Pass this in as a variable with 1password
       private_key = file("~/.ssh/id_rsa_openoakland")

--- a/modules/oakcrime/terraform.tf
+++ b/modules/oakcrime/terraform.tf
@@ -1,3 +1,4 @@
+// passed in to the module via a "providers" block:
 provider "aws" {
   alias = "cloudfront"
 }
@@ -31,7 +32,7 @@ module "env_web_production" {
   app_name     = "oakcrime"
   dns_zone     = "aws.openoakland.org"
   key_pair     = "oakcrime"
-  security_groups = ["${module.db_production.security_group_name}"]
+  security_groups = [module.db_production.security_group_name]
 
   environment_variables = {
     DATABASE_URL        = module.db_production.postgis_database_url

--- a/modules/oakcrime/terraform.tf
+++ b/modules/oakcrime/terraform.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  alias = "cloudfront"
+}
+
 module "ci_user" {
   source = "github.com/openoakland/terraform-modules//eb_deploy_user?ref=v2.0.0"
 
@@ -15,7 +19,7 @@ module "db_production" {
 
   db_engine_version = "10.6"
   db_name     = "oakcrime"
-  db_password = "${var.prod_db_password}"
+  db_password = var.prod_db_password
   db_username = "oakcrime"
   namespace   = "oakcrime-production"
 }
@@ -30,10 +34,12 @@ module "env_web_production" {
   security_groups = ["${module.db_production.security_group_name}"]
 
   environment_variables = {
-    DATABASE_URL = "${module.db_production.postgis_database_url}"
-    EMAIL_URL    = "smtp://localhost"
-    SECRET_KEY   = "${var.prod_django_secret_key}"
-    SERVER_EMAIL = "root@localhost"
+    DATABASE_URL        = module.db_production.postgis_database_url
+    EMAIL_URL           = "smtp://localhost"
+    GOOGLE_MAPS_API_KEY = var.prod_google_maps_api_key
+    OPD_KEY             = var.prod_opd_key
+    SECRET_KEY          = var.prod_django_secret_key
+    SERVER_EMAIL        = "root@localhost"
   }
 }
 
@@ -44,14 +50,16 @@ module "env_worker_production" {
   app_name     = "oakcrime"
   key_pair     = "oakcrime"
   name         = "oakcrime-production-worker"
-  security_groups = ["${module.db_production.security_group_name}"]
+  security_groups = [module.db_production.security_group_name]
 
   environment_variables = {
-    DATABASE_URL    = "${module.db_production.postgis_database_url}"
-    EMAIL_URL       = "smtp://localhost"
-    OAKCRIME_WORKER = "1"
-    SECRET_KEY      = "${var.prod_django_secret_key}"
-    SERVER_EMAIL    = "root@localhost"
-    SOCRATA_KEY     = "${var.prod_socrata_key}"
+    DATABASE_URL        = module.db_production.postgis_database_url
+    EMAIL_URL           = "smtp://localhost"
+    GOOGLE_MAPS_API_KEY = var.prod_google_maps_api_key
+    OAKCRIME_WORKER     = "1"
+    OPD_KEY             = var.prod_opd_key
+    SECRET_KEY          = var.prod_django_secret_key
+    SERVER_EMAIL        = "root@localhost"
+    SOCRATA_KEY         = var.prod_socrata_key
   }
 }

--- a/modules/oakcrime/terraform.tf
+++ b/modules/oakcrime/terraform.tf
@@ -35,10 +35,15 @@ module "env_web_production" {
   security_groups = [module.db_production.security_group_name]
 
   environment_variables = {
+    BOX_CLIENT_ID       = var.prod_box_client_id
+    BOX_CLIENT_SECRET   = var.prod_box_client_secret
+    BOX_ENTERPRISE_ID   = var.prod_box_enterprise_id
+    BOX_PASS_PHRASE     = var.prod_box_pass_phrase
+    BOX_PUBLIC_KEY_ID   = var.prod_box_public_key_id
+    BOX_RSA_KEY         = var.prod_box_rsa_key
     DATABASE_URL        = module.db_production.postgis_database_url
     EMAIL_URL           = "smtp://localhost"
     GOOGLE_MAPS_API_KEY = var.prod_google_maps_api_key
-    OPD_KEY             = var.prod_opd_key
     SECRET_KEY          = var.prod_django_secret_key
     SERVER_EMAIL        = "root@localhost"
   }
@@ -54,11 +59,16 @@ module "env_worker_production" {
   security_groups = [module.db_production.security_group_name]
 
   environment_variables = {
+    BOX_CLIENT_ID       = var.prod_box_client_id
+    BOX_CLIENT_SECRET   = var.prod_box_client_secret
+    BOX_ENTERPRISE_ID   = var.prod_box_enterprise_id
+    BOX_PASS_PHRASE     = var.prod_box_pass_phrase
+    BOX_PUBLIC_KEY_ID   = var.prod_box_public_key_id
+    BOX_RSA_KEY         = var.prod_box_rsa_key
     DATABASE_URL        = module.db_production.postgis_database_url
     EMAIL_URL           = "smtp://localhost"
     GOOGLE_MAPS_API_KEY = var.prod_google_maps_api_key
     OAKCRIME_WORKER     = "1"
-    OPD_KEY             = var.prod_opd_key
     SECRET_KEY          = var.prod_django_secret_key
     SERVER_EMAIL        = "root@localhost"
     SOCRATA_KEY         = var.prod_socrata_key

--- a/modules/oakcrime/variables.tf
+++ b/modules/oakcrime/variables.tf
@@ -5,18 +5,28 @@ variable "zone_id" {}
 # pwgen -s -N 1 20
 variable "prod_db_password" {
   description = "Production password for the RDS database."
-  type        = "string"
+  type        = string
 }
 
 # pwgen -s -N 1 50
 variable "prod_django_secret_key" {
   description = "Production SECRET_KEY setting to provide the Django application."
-  type        = "string"
+  type        = string
+}
+
+variable "prod_google_maps_api_key" {
+  description = "Key for Google Maps API used for geocoding"
+  type        = string
+}
+
+variable "prod_opd_key" {
+  description = "Key for accessing OPD Box.com API"
+  type        = string
 }
 
 variable "prod_socrata_key" {
   description = "Socrata API key for accessing data.oaklandnet.com"
-  type        = "string"
+  type        = string
 }
 
 variable "dns_zone" {

--- a/modules/oakcrime/variables.tf
+++ b/modules/oakcrime/variables.tf
@@ -2,6 +2,36 @@ variable "security_group_name" {}
 variable "key_pair_id" {}
 variable "zone_id" {}
 
+variable "prod_box_enterprise_id" {
+  description = "Box Enterprise ID for Patrol log fetching."
+  type = string
+}
+
+variable "prod_box_client_id" {
+  description = "Box Client ID for Patrol log fetching."
+  type = string
+}
+
+variable "prod_box_client_secret" {
+  description = "Box Client secret for Patrol log fetching."
+  type = string
+}
+
+variable "prod_box_public_key_id" {
+  description = "Box public key ID for Patrol log fetching."
+  type = string
+}
+
+variable "prod_box_rsa_key" {
+  description = "Box RSA key for Patrol log fetching."
+  type = string
+}
+
+variable "prod_box_pass_phrase" {
+  description = "Box RSA key passphrase for Patrol log fetching."
+  type = string
+}
+
 # pwgen -s -N 1 20
 variable "prod_db_password" {
   description = "Production password for the RDS database."
@@ -16,11 +46,6 @@ variable "prod_django_secret_key" {
 
 variable "prod_google_maps_api_key" {
   description = "Key for Google Maps API used for geocoding"
-  type        = string
-}
-
-variable "prod_opd_key" {
-  description = "Key for accessing OPD Box.com API"
   type        = string
 }
 

--- a/modules/openoakland.org/main.tf
+++ b/modules/openoakland.org/main.tf
@@ -17,5 +17,5 @@ module "ci_user" {
   source = "github.com/openoakland/terraform-modules//s3_deploy_user"
 
   username      = "ci-openoakland-org"
-  s3_bucket_arn = "${module.site.s3_bucket_arn}"
+  s3_bucket_arn = module.site.s3_bucket_arn
 }

--- a/modules/openoakland.org/main.tf
+++ b/modules/openoakland.org/main.tf
@@ -1,24 +1,20 @@
 provider "aws" {
-  alias = "main"
-}
-
-provider "aws" {
   alias = "cloudfront"
 }
 
 module "site" {
-  source = "github.com/openoakland/terraform-modules//s3_cloudfront_website?ref=s3-cloudfront-website"
+  source = "github.com/openoakland/terraform-modules//s3_cloudfront_website"
   host   = "beta"
   zone   = "aws.openoakland.org"
 
   providers = {
-    aws.main       = "aws.main"
-    aws.cloudfront = "aws.cloudfront"
+    aws.main       = aws
+    aws.cloudfront = aws.cloudfront
   }
 }
 
 module "ci_user" {
-  source = "github.com/openoakland/terraform-modules//s3_deploy_user?ref=s3-cloudfront-website"
+  source = "github.com/openoakland/terraform-modules//s3_deploy_user"
 
   username      = "ci-openoakland-org"
   s3_bucket_arn = "${module.site.s3_bucket_arn}"

--- a/modules/openoakland.org/outputs.tf
+++ b/modules/openoakland.org/outputs.tf
@@ -1,9 +1,9 @@
 output "aws_access_key_id" {
-  value     = "${module.ci_user.access_key_id}"
+  value     = module.ci_user.access_key_id
   sensitive = true
 }
 
 output "aws_secret_access_key" {
-  value     = "${module.ci_user.secret_access_key}"
+  value     = module.ci_user.secret_access_key
   sensitive = true
 }

--- a/oakcrime.tf
+++ b/oakcrime.tf
@@ -14,8 +14,28 @@ variable "oakcrime_prod_google_maps_api_key" {
   description = "Google Maps API key for the production app."
 }
 
-variable "oakcrime_prod_opd_key" {
-  description = "opd_key for the production app."
+variable "oakcrime_prod_box_enterprise_id" {
+  description = "BOX_ENTERPRISE_ID for the production app."
+}
+
+variable "oakcrime_prod_box_client_id" {
+  description = "BOX_CLIENT_ID for the production app."
+}
+
+variable "oakcrime_prod_box_client_secret" {
+  description = "BOX_CLIENT_SECRET for the production app."
+}
+
+variable "oakcrime_prod_box_public_key_id" {
+  description = "BOX_PUBLIC_KEY_ID for the production app."
+}
+
+variable "oakcrime_prod_box_rsa_key" {
+  description = "BOX_RSA_KEY for the production app."
+}
+
+variable "oakcrime_prod_box_pass_phrase" {
+  description = "BOX_PASS_PHRASE for the production app."
 }
 
 module "oakcrime" {
@@ -25,12 +45,17 @@ module "oakcrime" {
   zone_id             = data.aws_route53_zone.openoakland.id
 
   # Beanstalk apps
+  dns_zone                 = data.aws_route53_zone.openoakland.name
+  prod_box_client_id       = var.oakcrime_prod_box_client_id
+  prod_box_client_secret   = var.oakcrime_prod_box_client_secret
+  prod_box_enterprise_id   = var.oakcrime_prod_box_enterprise_id
+  prod_box_pass_phrase     = var.oakcrime_prod_box_pass_phrase
+  prod_box_public_key_id   = var.oakcrime_prod_box_public_key_id
+  prod_box_rsa_key         = var.oakcrime_prod_box_rsa_key
   prod_db_password         = var.oakcrime_prod_db_password
   prod_django_secret_key   = var.oakcrime_prod_django_secret_key
   prod_google_maps_api_key = var.oakcrime_prod_google_maps_api_key
-  prod_opd_key             = var.oakcrime_prod_opd_key
   prod_socrata_key         = var.oakcrime_prod_socrata_key
-  dns_zone                 = data.aws_route53_zone.openoakland.name
 }
 
 output "oakcrime_ci_aws_access_key_id" {

--- a/oakcrime.tf
+++ b/oakcrime.tf
@@ -10,25 +10,35 @@ variable "oakcrime_prod_socrata_key" {
   description = "socrata_key for the production app."
 }
 
+variable "oakcrime_prod_google_maps_api_key" {
+  description = "Google Maps API key for the production app."
+}
+
+variable "oakcrime_prod_opd_key" {
+  description = "opd_key for the production app."
+}
+
 module "oakcrime" {
   source              = "./modules/oakcrime"
-  security_group_name = "${aws_security_group.ssh_and_web.name}"
-  key_pair_id         = "${aws_key_pair.openoakland.id}"
-  zone_id             = "${data.aws_route53_zone.openoakland.id}"
+  security_group_name = aws_security_group.ssh_and_web.name
+  key_pair_id         = aws_key_pair.openoakland.id
+  zone_id             = data.aws_route53_zone.openoakland.id
 
   # Beanstalk apps
-  prod_db_password       = "${var.oakcrime_prod_db_password}"
-  prod_django_secret_key = "${var.oakcrime_prod_django_secret_key}"
-  prod_socrata_key       = "${var.oakcrime_prod_socrata_key}"
-  dns_zone               = "${data.aws_route53_zone.openoakland.name}"
+  prod_db_password         = var.oakcrime_prod_db_password
+  prod_django_secret_key   = var.oakcrime_prod_django_secret_key
+  prod_google_maps_api_key = var.oakcrime_prod_google_maps_api_key
+  prod_opd_key             = var.oakcrime_prod_opd_key
+  prod_socrata_key         = var.oakcrime_prod_socrata_key
+  dns_zone                 = data.aws_route53_zone.openoakland.name
 }
 
 output "oakcrime_ci_aws_access_key_id" {
-  value     = "${module.oakcrime.ci_aws_access_key_id}"
+  value     = module.oakcrime.ci_aws_access_key_id
   sensitive = true
 }
 
 output "oakcrime_ci_aws_secret_access_key" {
-  value     = "${module.oakcrime.ci_aws_secret_access_key}"
+  value     = module.oakcrime.ci_aws_secret_access_key
   sensitive = true
 }

--- a/openoakland.org.tf
+++ b/openoakland.org.tf
@@ -2,17 +2,17 @@ module "openoakland_org" {
   source = "./modules/openoakland.org"
 
   providers = {
-    aws.main = "aws"
-    aws.cloudfront = "aws.cloudfront"
+    aws            = aws
+    aws.cloudfront = aws.cloudfront
   }
 }
 
 output "openoakland_org_aws_access_key_id" {
-  value     = "${module.openoakland_org.aws_access_key_id}"
+  value     = module.openoakland_org.aws_access_key_id
   sensitive = true
 }
 
 output "openoakland_org_aws_secret_access_key" {
-  value     = "${module.openoakland_org.aws_secret_access_key}"
+  value     = module.openoakland_org.aws_secret_access_key
   sensitive = true
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -15,47 +15,47 @@ data "aws_route53_zone" "openoakland" {
 
 terraform {
   backend "s3" {
-    bucket = "openoakland-infra"
-    key    = "terraform.tfstate"
-    region = "us-west-2"
+    bucket         = "openoakland-infra"
+    key            = "terraform.tfstate"
+    region         = "us-west-2"
     dynamodb_table = "openoakland_infra"
   }
 }
 
 resource "aws_security_group" "ssh_and_web" {
-  name = "ssh_and_web"
+  name        = "ssh_and_web"
   description = "Allow SSH and Web connections"
 
   ingress {
-    from_port = 22
-    to_port = 22
-    protocol = "tcp"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
-    from_port = 80
-    to_port = 80
-    protocol = "tcp"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
-    from_port = 443
-    to_port = 443
-    protocol = "tcp"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
 
 resource "aws_key_pair" "openoakland" {
-  key_name = "OpenOakland"
-  public_key = "${file("ssh-keys/openoakland.pub")}"
+  key_name   = "OpenOakland"
+  public_key = file("ssh-keys/openoakland.pub")
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
In order to harvest patrol logs from Box, we seem to need this super
complicated auth regime with six secrets. The `opd_key` was a red
herring that turned out not to be necessary.