### PR TITLE
Fix Cloudfront by adding an alias for "openoakland.org"

### DIFF
--- a/modules/openoakland.org/main.tf
+++ b/modules/openoakland.org/main.tf
@@ -6,6 +6,7 @@ module "site" {
   source = "github.com/openoakland/terraform-modules//s3_cloudfront_website"
   host   = "beta"
   zone   = "aws.openoakland.org"
+  aliases = ["openoakland.org"]
 
   providers = {
     aws.main       = aws


### PR DESCRIPTION
See https://github.com/openoakland/terraform-modules/pull/11 for the
details.